### PR TITLE
Fix: add only-fixed=true to Docker Scout CVE scan

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,6 +119,7 @@ runs:
         dockerhub-user: ${{ inputs.dockerhub_username }}
         dockerhub-password: ${{ inputs.dockerhub_password }}
         only-severities: critical,high
+        only-fixed: true
         write-comment: ${{ github.event_name == 'pull_request' }}
         github-token: ${{ inputs.github_token }}
         exit-code: ${{ inputs.allow_vulnerabilities != 'true' }}


### PR DESCRIPTION
Adds only-fixed: true to the Docker Scout CVE scan step to prevent PR failures on unpatchable Debian CVEs (e.g., CVE‑2026‑5435).
