### PR TITLE
fix zizmor and version

### DIFF
--- a/.github/workflows/test-and-tag.yaml
+++ b/.github/workflows/test-and-tag.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get Secrets
-        uses: bitwarden/sm-action@14f92f1d294ae3c2b6a3845d389cd2c318b0dfd8 # v2.2.0
+        uses: bitwarden/sm-action@27c0c9dcab679d7250dbab91227c85b49ffa5e0f # v3.0.0
         with:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
           secrets: |
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           dockerfile: './test/Dockerfile'
       - name: Create tag
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: ${{ github.event.inputs.tag != '' }}
         with:
           script: |

--- a/.github/workflows/test-and-tag.yaml
+++ b/.github/workflows/test-and-tag.yaml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get Secrets
-        uses: bitwarden/sm-action@v2.2.0
+        uses: bitwarden/sm-action@14f92f1d294ae3c2b6a3845d389cd2c318b0dfd8 # v2.2.0
         with:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
           secrets: |
             d0a9af63-dea5-476f-b35a-b18501152d9a > DOCKERHUB_USERNAME
             bf06dbe4-5b30-4020-b39e-b18501151ace > DOCKERHUB_ACCESS_TOKEN
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Test Action
         uses: ./
         with:
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           dockerfile: './test/Dockerfile'
       - name: Create tag
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         if: ${{ github.event.inputs.tag != '' }}
         with:
           script: |

--- a/action.yml
+++ b/action.yml
@@ -71,10 +71,10 @@ runs:
         images: ${{ inputs.image }}
         flavor: latest=${{ inputs.tag_latest }}
         tags: |
-          type=raw,value=${{ inputs.version }},enable=${{ (inputs.version && 'true') || 'false' }}
-          type=edge,enable=${{ (inputs.version && 'false') || 'true' }}
-          type=ref,event=pr,enable=${{ (inputs.version && 'false') || 'true' }}
-          type=sha,enable=${{ (inputs.tag_sha == 'true' && 'true') || 'false' }}
+          type=raw,value=${{ inputs.version || 'latest' }},enable=${{ inputs.version != '' || inputs.tag_latest == 'true' }}
+          type=edge,enable=${{ inputs.version == '' }}
+          type=ref,event=pr,enable=${{ inputs.version == '' }}
+          type=sha,enable=${{ inputs.tag_sha == 'true' }}
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
 

--- a/action.yml
+++ b/action.yml
@@ -62,11 +62,11 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
     - name: Generate Docker Tags
       id: meta
-      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
       with:
         images: ${{ inputs.image }}
         flavor: latest=${{ inputs.tag_latest }}
@@ -81,22 +81,34 @@ runs:
     - name: Configuration
       id: image
       shell: bash
+      env:
+        STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
+        INPUTS_IMAGE: ${{ inputs.image }}
       run: |
-        version="${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}"
-        echo "version=$version" >> $GITHUB_OUTPUT
-        echo "version: $version"
-        echo "image: ${{ inputs.image }}:$version"
-        
-        registry=$(echo "${{ inputs.image }}" | cut -d/ -f1)
+        version="${STEPS_META_OUTPUTS_VERSION}"
+        if [[ -z "$version" ]]; then
+          echo "Failed to determine Docker image version from docker/metadata-action"
+          exit 1
+        fi
+
+        image_ref="${INPUTS_IMAGE}:$version"
+
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "image_ref=$image_ref" >> "$GITHUB_OUTPUT"
+            
+        registry=$(echo "${INPUTS_IMAGE}" | cut -d/ -f1)
         if [[ "$registry" != *"."* ]]; then
           registry="docker.io"
         fi
+        echo "registry=$registry" >> "$GITHUB_OUTPUT"
+    
+        echo "version: $version"
+        echo "image: $image_ref"
         echo "registry: $registry"
-        echo "registry=$registry" >> $GITHUB_OUTPUT
-        
+
 
     - name: Build image (local load for scanning)
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         load: true
         context: ${{ inputs.context }}
@@ -110,12 +122,12 @@ runs:
 
     - name: Docker Scout - CVE scan
       continue-on-error: ${{ inputs.allow_vulnerabilities == 'true' }}
-      uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7
+      uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7 # v1.20.3
       with:
         debug: true
         verbose-debug: true
         command: cves
-        image: local://${{ inputs.image }}:${{ steps.image.outputs.version }}
+        image: local://${{ steps.image.outputs.image_ref }}
         dockerhub-user: ${{ inputs.dockerhub_username }}
         dockerhub-password: ${{ inputs.dockerhub_password }}
         only-severities: critical,high
@@ -125,7 +137,7 @@ runs:
         exit-code: ${{ inputs.allow_vulnerabilities != 'true' }}
 
     - name: Login to ${{ steps.image.outputs.registry }}
-      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
       if: ${{ inputs.username != '' && inputs.password != '' }}
       with:
         registry: ${{ steps.image.outputs.registry }}
@@ -135,10 +147,12 @@ runs:
     - name: ACR Login
       if: ${{ contains(steps.image.outputs.registry , '.azurecr.io') }}
       shell: bash
-      run: az acr login --name ${{ steps.image.outputs.registry }}
+      env:
+        STEPS_IMAGE_OUTPUTS_REGISTRY: ${{ steps.image.outputs.registry }}
+      run: az acr login --name ${STEPS_IMAGE_OUTPUTS_REGISTRY}
 
     - name: Push image with attestations
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
       with:
         push: true
         context: ${{ inputs.context }}
@@ -153,7 +167,7 @@ runs:
         outputs: type=registry
 
     - name: Send Slack notification
-      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       if: failure() && inputs.slack_webhook_url != ''
       with:
         webhook: ${{ inputs.slack_webhook_url }}

--- a/action.yml
+++ b/action.yml
@@ -62,11 +62,11 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
     - name: Generate Docker Tags
       id: meta
-      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
       with:
         images: ${{ inputs.image }}
         flavor: latest=${{ inputs.tag_latest }}
@@ -108,7 +108,7 @@ runs:
 
 
     - name: Build image (local load for scanning)
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         load: true
         context: ${{ inputs.context }}
@@ -122,7 +122,7 @@ runs:
 
     - name: Docker Scout - CVE scan
       continue-on-error: ${{ inputs.allow_vulnerabilities == 'true' }}
-      uses: docker/scout-action@8910519cee8ac046f3ee99686b0dc6654d5ba1a7 # v1.20.3
+      uses: docker/scout-action@cd72f264beff1cd72735de31148b9d3244a0234a # v1.21.0
       with:
         debug: true
         verbose-debug: true
@@ -137,7 +137,7 @@ runs:
         exit-code: ${{ inputs.allow_vulnerabilities != 'true' }}
 
     - name: Login to ${{ steps.image.outputs.registry }}
-      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
       if: ${{ inputs.username != '' && inputs.password != '' }}
       with:
         registry: ${{ steps.image.outputs.registry }}
@@ -152,7 +152,7 @@ runs:
       run: az acr login --name ${STEPS_IMAGE_OUTPUTS_REGISTRY}
 
     - name: Push image with attestations
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         push: true
         context: ${{ inputs.context }}
@@ -167,7 +167,7 @@ runs:
         outputs: type=registry
 
     - name: Send Slack notification
-      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
       if: failure() && inputs.slack_webhook_url != ''
       with:
         webhook: ${{ inputs.slack_webhook_url }}


### PR DESCRIPTION
This pull request updates several GitHub Actions and Docker-related dependencies to their latest versions, adds explicit version pinning via commit hashes, and improves the reliability and clarity of Docker image version handling in the workflow. There are also minor improvements to environment variable usage and output management.

**Dependency updates and version pinning:**

* Updated all major GitHub Actions used in `.github/workflows/test-and-tag.yaml` and `action.yml` to their latest versions, now pinned by commit hash for improved security and reproducibility. This includes actions such as `bitwarden/sm-action`, `actions/checkout`, `actions/github-script`, `docker/setup-buildx-action`, `docker/metadata-action`, `docker/build-push-action`, `docker/scout-action`, `docker/login-action`, and `slackapi/slack-github-action`. [[1]](diffhunk://#diff-7f3314ba19e7ce9c15b73f131d1b8cbb8c415d0c1c7dcf2e5cb3c64d6f69d2d0L24-R30) [[2]](diffhunk://#diff-7f3314ba19e7ce9c15b73f131d1b8cbb8c415d0c1c7dcf2e5cb3c64d6f69d2d0L46-R46) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L65-R69) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L113-R130) [[5]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L128-R140) [[6]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L138-R155) [[7]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L156-R170)

**Docker image version and output handling:**

* Improved how Docker image version and reference are extracted and passed between workflow steps by using environment variables and explicit outputs (`version`, `image_ref`, `registry`), making the workflow more robust and easier to debug.
* Updated references to use the new `image_ref` output for local image scanning and other steps, ensuring consistency.

**Environment variable and output management:**

* Switched to using environment variables for passing values between steps (e.g., `STEPS_META_OUTPUTS_VERSION`, `INPUTS_IMAGE`, `STEPS_IMAGE_OUTPUTS_REGISTRY`) for improved clarity and maintainability. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R84-R111) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L138-R155)

No application code was changed; these updates are focused on CI/CD pipeline reliability, security, and maintainability.