### PR TITLE
auto-version [major]

### DIFF
--- a/.github/workflows/test-and-tag.yaml
+++ b/.github/workflows/test-and-tag.yaml
@@ -1,5 +1,9 @@
 name: Test and Tag
 on:
+  pull_request: {}
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/test-and-tag.yaml
+++ b/.github/workflows/test-and-tag.yaml
@@ -2,32 +2,43 @@ name: Test and Tag
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag Name'
+      bump:
+        description: 'The type of semantic version increment to make'
         required: true
-        default: 'dev'
+        default: 'patch'
         type: choice
         options:
-          - 'dev'
-          - 'stable'
-          - ''
+          - major
+          - minor
+          - patch
+          - none
+      dry_run:
+        description: 'If true, only calculate the new version and exit successfully.'
+        required: false
+        default: false
 
 permissions:
   contents: write
   packages: write
+
+env:
+  bump: ${{ github.event_name == 'pull_request' && 'none' || github.event_name == 'workflow_dispatch' && github.event.inputs.bump || 'patch' }}
+  prerelease_version: ${{ github.event_name == 'pull_request' && format('pr{0}', github.event.number) || '' }}
+  dry_run: ${{ github.event_name == 'pull_request' && 'true' || github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
 
 jobs:
   test-and-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Get Secrets
-        uses: bitwarden/sm-action@27c0c9dcab679d7250dbab91227c85b49ffa5e0f # v3.0.0
+        uses: bitwarden/sm-action@1238aae8fc64b212641190a9227c8a734ab1a793 # v3.0.1
         with:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
           secrets: |
             d0a9af63-dea5-476f-b35a-b18501152d9a > DOCKERHUB_USERNAME
             bf06dbe4-5b30-4020-b39e-b18501151ace > DOCKERHUB_ACCESS_TOKEN
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Test Action
         uses: ./
         with:
@@ -35,32 +46,19 @@ jobs:
           version: testing
           build_args: |
             TEST=1
-          image: ghcr.io/enosix/ghac-docker-github/testing #TODO: maybe make this test image build something useful?
+          image: ghcr.io/enosix/ghac-docker-github/testing
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dockerhub_username: ${{ env.DOCKERHUB_USERNAME }}
           dockerhub_password: ${{ env.DOCKERHUB_ACCESS_TOKEN }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           dockerfile: './test/Dockerfile'
-      - name: Create tag
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        if: ${{ github.event.inputs.tag != '' }}
+
+      - name: Generate Semantic Version
+        uses: enosix/github-action-generate-semver@4ab2e5251fb8c5b9b06eb65b22c0e25daba76311 # v4.0.1
         with:
-          script: |
-            try {
-              await github.rest.git.updateRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'tags/${{ github.event.inputs.tag }}',
-                sha: context.sha,
-              })
-            } catch (err) {
-              console.log(err)
-            
-              await github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'refs/tags/${{ github.event.inputs.tag }}',
-                sha: context.sha,
-              })
-            }
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          bump: ${{ env.bump }}
+          prerelease_version: ${{ env.prerelease_version }}
+          dry_run: ${{ env.dry_run }}
+          detect_bump: true

--- a/.github/workflows/test-and-tag.yaml
+++ b/.github/workflows/test-and-tag.yaml
@@ -24,6 +24,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 env:
   bump: ${{ github.event_name == 'pull_request' && 'none' || github.event_name == 'workflow_dispatch' && github.event.inputs.bump || 'patch' }}

--- a/action.yml
+++ b/action.yml
@@ -62,11 +62,11 @@ runs:
   using: "composite"
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
     - name: Generate Docker Tags
       id: meta
-      uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       with:
         images: ${{ inputs.image }}
         flavor: latest=${{ inputs.tag_latest }}
@@ -108,7 +108,7 @@ runs:
 
 
     - name: Build image (local load for scanning)
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         load: true
         context: ${{ inputs.context }}
@@ -122,7 +122,7 @@ runs:
 
     - name: Docker Scout - CVE scan
       continue-on-error: ${{ inputs.allow_vulnerabilities == 'true' }}
-      uses: docker/scout-action@cd72f264beff1cd72735de31148b9d3244a0234a # v1.21.0
+      uses: docker/scout-action@2688993af7bafd6ba8c6a74ec652442be91dd82b # v1.23.1
       with:
         debug: true
         verbose-debug: true
@@ -137,7 +137,7 @@ runs:
         exit-code: ${{ inputs.allow_vulnerabilities != 'true' }}
 
     - name: Login to ${{ steps.image.outputs.registry }}
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
       if: ${{ inputs.username != '' && inputs.password != '' }}
       with:
         registry: ${{ steps.image.outputs.registry }}
@@ -152,7 +152,7 @@ runs:
       run: az acr login --name ${STEPS_IMAGE_OUTPUTS_REGISTRY}
 
     - name: Push image with attestations
-      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         push: true
         context: ${{ inputs.context }}
@@ -167,7 +167,7 @@ runs:
         outputs: type=registry
 
     - name: Send Slack notification
-      uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+      uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
       if: failure() && inputs.slack_webhook_url != ''
       with:
         webhook: ${{ inputs.slack_webhook_url }}


### PR DESCRIPTION
This pull request updates the CI/CD pipeline to improve semantic versioning, enhance workflow flexibility, and keep dependencies up to date. The main changes include switching from manual tag input to semantic version bumps, adding a dry run option, and updating several GitHub Actions to their latest versions for improved reliability and security.

**Workflow improvements:**

* Changed the workflow dispatch input in `.github/workflows/test-and-tag.yaml` from a manual `tag` entry to a `bump` option for semantic versioning (`major`, `minor`, `patch`, or `none`), and added a `dry_run` option to allow calculating the new version without making changes.
* Added environment variables to support the new versioning logic and handle pull requests and workflow dispatch events more flexibly.
* Replaced the manual tag creation step with the `enosix/github-action-generate-semver` action for automated semantic version generation and tagging.

**Dependency updates:**

* Updated several GitHub Actions to newer versions in both `.github/workflows/test-and-tag.yaml` and `action.yml`, including:
  - `bitwarden/sm-action` to v3.0.1
  - `actions/checkout` to v7.0.0
  - `docker/setup-buildx-action` to v4.2.0
  - `docker/metadata-action` to v6.2.0
  - `docker/build-push-action` to v7.3.0 [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L111-R111) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L155-R155)
  - `docker/scout-action` to v1.23.1
  - `docker/login-action` to v4.4.0
  - `slackapi/slack-github-action` to v4.0.0

These changes make the release process more robust, automate version management, and ensure the pipeline uses the latest, most secure actions.